### PR TITLE
Refactor: extract shared helpers and provider metadata registry

### DIFF
--- a/src/llmeter/config.py
+++ b/src/llmeter/config.py
@@ -22,9 +22,10 @@ Provider-specific settings (api_key, monthly_budget, etc.) are passed through.
 from __future__ import annotations
 
 import json
-import os
 from dataclasses import dataclass, field
 from pathlib import Path
+
+from .providers.helpers import config_dir
 
 
 @dataclass
@@ -80,10 +81,7 @@ class AppConfig:
 
 def config_path() -> Path:
     """Return the config file path, preferring XDG."""
-    xdg = os.environ.get("XDG_CONFIG_HOME", "")
-    if xdg:
-        return Path(xdg) / "llmeter" / "config.json"
-    return Path.home() / ".config" / "llmeter" / "config.json"
+    return config_dir("config.json")
 
 
 def load_config() -> AppConfig:

--- a/src/llmeter/models.py
+++ b/src/llmeter/models.py
@@ -93,39 +93,53 @@ class ProviderResult:
 
 # ── Provider display metadata ──────────────────────────────────────────────
 
-PROVIDERS = {
-    "codex": {
-        "name": "Codex",
-        "color": "#10a37f",
-        "icon": "⬡",
-        "primary_label": "Session (5h)",
-        "secondary_label": "Weekly",
-    },
-    "claude": {
-        "name": "Claude",
-        "color": "#d4a27f",
-        "icon": "◈",
-        "primary_label": "Session (5h)",
-        "secondary_label": "Weekly",
-        "tertiary_label": "Sonnet",
-    },
-    "gemini": {
-        "name": "Gemini",
-        "color": "#ab87ea",
-        "icon": "✦",
-        "primary_label": "Pro (24h)",
-        "secondary_label": "Flash (24h)",
-    },
-    "openai-api": {
-        "name": "OpenAI API",
-        "color": "#10a37f",
-        "icon": "⬡",
-        "primary_label": "Spend",
-    },
-    "anthropic-api": {
-        "name": "Anthropic API",
-        "color": "#d4a27f",
-        "icon": "◈",
-        "primary_label": "Spend",
-    },
+
+@dataclass(frozen=True)
+class ProviderMeta:
+    """Display metadata for a provider (single source of truth)."""
+    id: str
+    name: str
+    icon: str
+    color: str
+    primary_label: str = "Session"
+    secondary_label: str = "Weekly"
+    tertiary_label: str = "Sonnet"
+
+    def to_result(self, **overrides) -> ProviderResult:
+        """Create a ProviderResult pre-filled with this provider's metadata."""
+        kwargs: dict = dict(
+            provider_id=self.id,
+            display_name=self.name,
+            icon=self.icon,
+            color=self.color,
+            primary_label=self.primary_label,
+            secondary_label=self.secondary_label,
+            tertiary_label=self.tertiary_label,
+        )
+        kwargs.update(overrides)
+        return ProviderResult(**kwargs)
+
+
+PROVIDERS: dict[str, ProviderMeta] = {
+    "codex": ProviderMeta(
+        id="codex", name="Codex", icon="⬡", color="#10a37f",
+        primary_label="Session (5h)", secondary_label="Weekly",
+    ),
+    "claude": ProviderMeta(
+        id="claude", name="Claude", icon="◈", color="#d4a27f",
+        primary_label="Session (5h)", secondary_label="Weekly",
+        tertiary_label="Sonnet",
+    ),
+    "gemini": ProviderMeta(
+        id="gemini", name="Gemini", icon="✦", color="#ab87ea",
+        primary_label="Pro (24h)", secondary_label="Flash (24h)",
+    ),
+    "openai-api": ProviderMeta(
+        id="openai-api", name="OpenAI API", icon="⬡", color="#10a37f",
+        primary_label="Spend",
+    ),
+    "anthropic-api": ProviderMeta(
+        id="anthropic-api", name="Anthropic API", icon="◈", color="#d4a27f",
+        primary_label="Spend",
+    ),
 }

--- a/src/llmeter/providers/anthropic_api.py
+++ b/src/llmeter/providers/anthropic_api.py
@@ -20,6 +20,7 @@ import aiohttp
 
 from ..models import (
     CostInfo,
+    PROVIDERS,
     ProviderIdentity,
     ProviderResult,
     RateWindow,
@@ -37,14 +38,7 @@ async def fetch_anthropic_api(
     """Fetch Anthropic API cost report for the current billing month."""
     settings = settings or {}
 
-    result = ProviderResult(
-        provider_id="anthropic-api",
-        display_name="Anthropic API",
-        icon="◈",
-        color="#d4a27f",
-        primary_label="Spend",
-        source="admin-api",
-    )
+    result = PROVIDERS["anthropic-api"].to_result(source="admin-api")
 
     # Resolve API key — prefer admin key
     api_key = (

--- a/src/llmeter/providers/claude_oauth.py
+++ b/src/llmeter/providers/claude_oauth.py
@@ -17,6 +17,8 @@ from typing import Optional
 
 import aiohttp
 
+from .helpers import config_dir
+
 # OAuth constants — Anthropic's shared public OAuth client ID,
 # used by Claude Code CLI, pi-mono, and llmeter alike.
 _CLIENT_ID_B64 = "OWQxYzI1MGEtZTYxYi00NGQ5LTg4ZWQtNTk0NGQxOTYyZjVl"
@@ -32,9 +34,7 @@ _EXPIRY_BUFFER_MS = 5 * 60 * 1000
 
 def _creds_path() -> Path:
     """Path to llmeter's own Claude OAuth credentials file."""
-    xdg = os.environ.get("XDG_CONFIG_HOME", "")
-    base = Path(xdg) if xdg else Path.home() / ".config"
-    return base / "llmeter" / "claude_oauth.json"
+    return config_dir("claude_oauth.json")
 
 
 # ── PKCE helpers ───────────────────────────────────────────

--- a/src/llmeter/providers/codex.py
+++ b/src/llmeter/providers/codex.py
@@ -21,25 +21,20 @@ import aiohttp
 
 from ..models import (
     CreditsInfo,
+    PROVIDERS,
     ProviderIdentity,
     ProviderResult,
     RateWindow,
 )
 from . import codex_oauth
+from .helpers import parse_iso8601
 
 USAGE_URL = "https://chatgpt.com/backend-api/api/codex/usage"
 
 
 async def fetch_codex(timeout: float = 20.0, settings: dict | None = None) -> ProviderResult:
     """Fetch Codex usage via direct API (preferred) or RPC fallback."""
-    result = ProviderResult(
-        provider_id="codex",
-        display_name="Codex",
-        icon="⬡",
-        color="#10a37f",
-        primary_label="Session (5h)",
-        secondary_label="Weekly",
-    )
+    result = PROVIDERS["codex"].to_result()
 
     # 1. Try direct API with own OAuth credentials
     creds = await codex_oauth.get_valid_credentials(timeout=timeout)
@@ -158,10 +153,7 @@ def _parse_rate_window(window: dict) -> RateWindow:
         if isinstance(resets_raw, (int, float)):
             resets_at = datetime.fromtimestamp(resets_raw, tz=timezone.utc)
         elif isinstance(resets_raw, str):
-            try:
-                resets_at = datetime.fromisoformat(resets_raw.replace("Z", "+00:00"))
-            except (ValueError, TypeError):
-                pass
+            resets_at = parse_iso8601(resets_raw)
 
     return RateWindow(
         used_percent=used_pct,

--- a/src/llmeter/providers/helpers.py
+++ b/src/llmeter/providers/helpers.py
@@ -1,0 +1,52 @@
+"""Shared helpers for llmeter providers."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+
+def config_dir(*parts: str) -> Path:
+    """Return a path under the llmeter XDG config directory.
+
+    >>> config_dir("codex_oauth.json")
+    PosixPath('/home/user/.config/llmeter/codex_oauth.json')
+    """
+    xdg = os.environ.get("XDG_CONFIG_HOME", "")
+    base = Path(xdg) if xdg else Path.home() / ".config"
+    return base / "llmeter" / Path(*parts) if parts else base / "llmeter"
+
+
+def parse_iso8601(s: str | None) -> Optional[datetime]:
+    """Parse an ISO 8601 datetime string, returning None on failure.
+
+    Handles the common ``"Z"`` suffix that Python < 3.11 can't parse
+    natively via ``fromisoformat``.
+    """
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+
+
+def decode_jwt_payload(token: str) -> Optional[dict]:
+    """Decode a JWT payload without signature verification.
+
+    Uses only the standard library (base64 + json).
+    """
+    parts = token.split(".")
+    if len(parts) != 3:
+        return None
+    try:
+        # base64url → standard base64, add padding
+        payload = parts[1].replace("-", "+").replace("_", "/")
+        payload += "=" * (-len(payload) % 4)
+        return json.loads(base64.b64decode(payload))
+    except Exception:
+        return None

--- a/src/llmeter/providers/openai_api.py
+++ b/src/llmeter/providers/openai_api.py
@@ -17,6 +17,7 @@ import aiohttp
 
 from ..models import (
     CostInfo,
+    PROVIDERS,
     ProviderIdentity,
     ProviderResult,
     RateWindow,
@@ -32,14 +33,7 @@ async def fetch_openai_api(
     """Fetch OpenAI API spend for the current billing month."""
     settings = settings or {}
 
-    result = ProviderResult(
-        provider_id="openai-api",
-        display_name="OpenAI API",
-        icon="⬡",
-        color="#10a37f",
-        primary_label="Spend",
-        source="api",
-    )
+    result = PROVIDERS["openai-api"].to_result(source="api")
 
     # Resolve API key
     api_key = (


### PR DESCRIPTION
- Add providers/helpers.py with config_dir(), parse_iso8601(), decode_jwt_payload()
- Consolidate 4 copies of XDG config path resolution into config_dir()
- Consolidate 3 copies of ISO 8601 parsing into parse_iso8601()
- Consolidate 2 copies of JWT decoding into decode_jwt_payload()
- Replace loose PROVIDERS dict with frozen ProviderMeta dataclass + to_result()
- All 5 providers now use PROVIDERS[id].to_result() instead of hardcoding metadata
- backend.py placeholder/error paths use ProviderMeta.to_result()
- Net reduction of ~90 lines, all standard library

Closes #2

https://claude.ai/code/session_018FEfchyHdo7MGV3c3PnxFi